### PR TITLE
Allow DefineArray behavior mirror DefineList when handed undefined

### DIFF
--- a/src/can-define-array.js
+++ b/src/can-define-array.js
@@ -95,7 +95,8 @@ class DefineArray extends MixedInArray {
 	}
 
 	static [Symbol.for("can.new")](items) {
-		return new this(...items);
+		let array = items || [];
+		return new this(...array);
 	}
 
 	push(...items) {

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -132,4 +132,9 @@ module.exports = function() {
 		let extended = new Extended("one", "two");
 		assert.equal(canReflect.isListLike(extended), true, "It is list like");
 	});
+
+	QUnit.test("can take undefined as a value with can.new", function(assert) {
+		let array = canReflect.new(DefineArray, undefined);
+		assert.deepEqual(array, [], "no values, just like with DefineList");
+	});
 };


### PR DESCRIPTION
With DefineList if you do: `canReflect.new(DefineList, undefined)` you
get an empty list. This makes DefineArray mirror that behavior.

Note that DefineList and DefineArray are different when called with
`new` like `new DefineArray(values)` and `new DefineList(values)`.
DefineArray behaves more like an Array.

The `can.new` symbol is where DefineArray behaves like DefineList. So
this is keeping with that. Closes #16