### PR TITLE
dispatching correct patches for .sort and .reverse

### DIFF
--- a/src/can-define-array.js
+++ b/src/can-define-array.js
@@ -177,6 +177,22 @@ var mutateMethods = {
 			insert: args.slice(2),
 			type: "splice"
 		}];
+	},
+	"sort": function(arr) {
+		return [{
+			index: 0,
+			deleteCount: arr.length,
+			insert: arr,
+			type: "splice"
+		}];
+	},
+	"reverse": function(arr) {
+		return [{
+			index: 0,
+			deleteCount: arr.length,
+			insert: arr,
+			type: "splice"
+		}];
 	}
 };
 

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -346,6 +346,33 @@ module.exports = function() {
 				patches: [
 					[{ type: "splice", index: 0, deleteCount: 1, insert: ["hello", "there"] }],
 				]
+			},
+			{
+				initialData: [ "fff", "xxx", "aaa" ],
+				method: "sort",
+				args: [],
+				events: [
+					{ type: 0, newVal: "aaa", oldVal: "fff" },
+					{ type: 1, newVal: "fff", oldVal: "xxx" },
+					{ type: 2, newVal: "xxx", oldVal: "aaa" },
+					{ type: "length", newVal: 3, oldVal: 3 }
+				],
+				patches: [
+					[{ type: "splice", index: 0, deleteCount: 3, insert: ["aaa", "fff", "xxx"] }],
+				]
+			},
+			{
+				initialData: [ "fff", "xxx", "aaa" ],
+				method: "reverse",
+				args: [],
+				events: [
+					{ type: 0, newVal: "aaa", oldVal: "fff" },
+					{ type: 2, newVal: "fff", oldVal: "aaa" },
+					{ type: "length", newVal: 3, oldVal: 3 }
+				],
+				patches: [
+					[{ type: "splice", index: 0, deleteCount: 3, insert: ["aaa", "xxx", "fff"] }],
+				]
 			}
 		];
 


### PR DESCRIPTION
closes https://github.com/canjs/can-define-array/issues/25.